### PR TITLE
modelsummary 1.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
     data.table,
     fabricatr,
     fixest,
+    gt,
     ivreg,
     knitr,
     lfe,

--- a/vignettes/articles/Different-Variants-of-the-Wild-Cluster-Bootstrap.Rmd
+++ b/vignettes/articles/Different-Variants-of-the-Wild-Cluster-Bootstrap.Rmd
@@ -20,6 +20,7 @@ To run all bootstrap types with the null hypothesis imposed on the bootstrap dat
 ```{r setup, warnings = FALSE}
 library(fwildclusterboot)
 library(modelsummary)
+options(modelsummary_factory_default = "gt")
 
 N <- 1000
 N_G1 <- 17


### PR DESCRIPTION
`kableExtra` does not appear to be actively maintained and it causes some problems on `pkgdown` websites and for installation on some platforms. In version 1.4.0, `modelsummary` will no longer depend on `kableExtra`. Instead it will give the user a choice to install any of the supported table-making package, and offer a function to set a persistent default.

Call setting:

```r
modelsummary(model, output = "gt")
```

Persistent setting stays only for the current session:

```r
options(modelsummary_factory_default = "gt")
```

Persistent setting stays across sessions:

```r
config_modelsummary(factory_default = "gt")
```

Developers of packages that use `modelsummary` in vignettes need to add a table-making package to `Suggests`.