### PR TITLE
Add support for `plm`

### DIFF
--- a/R/boottest_plm.r
+++ b/R/boottest_plm.r
@@ -1,0 +1,7 @@
+boottest.plm <- function(){
+
+    # copy from boottest.fixest and update for plm specifics
+
+
+
+}

--- a/R/model_matrix.R
+++ b/R/model_matrix.R
@@ -10,6 +10,35 @@ model_matrix <- function(object, ...) {
   UseMethod("model_matrix")
 }
 
+model_matrix.plm <- function(object, type, collin.rm = TRUE, ...) {
+  #' Enhanced model.matrix for objects of type plm
+  #' @method model_matrix felm
+  #' @param object An object of class plm
+  #' @param collin.rm Should collinear variables be dropped?
+  #' @param type 'rhs' for right-hand side variables, 'fixef' for fixed effects
+  #' @param ... Other arguments
+  #' @noRd
+  
+  dreamerr::check_arg(type, "charin(rhs, fixef)")
+  
+  if (type == "rhs") {
+    mm <- model.matrix(object)
+    if (collin.rm == TRUE) {
+      bn <- names(na.omit(coef(object)))
+      mm <- mm[, colnames(mm) %in% bn]
+    }
+  } else if (type == "fixef") {
+    mm <- index(object)
+    # make sure all fixed effect variables are factors
+    i <- seq_along(mm)
+    mm[, i] <- lapply(i, function(x) {
+      factor(mm[, x])
+    })
+  }
+  
+  mm
+}
+
 
 model_matrix.lm <- function(object, collin.rm = TRUE, ...) {
   #' Enhanced model.matrix for objects of type lm

--- a/R/preprocess2.R
+++ b/R/preprocess2.R
@@ -56,9 +56,9 @@ preprocess2.plm <-
     k <- length(na.omit(coef(object)))
 
     # plm specific checks
-    if(object$args$model != "within"){
-      rlang::abort("boottest() only supports estimation of 'within' models
-                  via the plm::plm().",
+    if(!(object$args$model %in% c("pooling", "within", "between"))){
+      rlang::abort("boottest() only supports estimation of 'pooling', 'within'
+                   and 'between' models via the plm::plm() function.",
                   use_cli_format = TRUE
       )
     }
@@ -66,7 +66,7 @@ preprocess2.plm <-
     is_iv <- FALSE
     has_fe <- FALSE
 
-    if(object$args$model == "within"){
+    if(object$args$model %in% c("within", "between")){
       has_fe <- TRUE
     }
 


### PR DESCRIPTION
`fwildclusterboot` can support the following models: 

- `pooling`
- `within`
- `between`. 

I need to add the following methods: 

- [ ] `model_matrix.plm`
- [ ] `boottest.plm`

- [ ] Last, I need to add tests. 