### PR TITLE
nudge citation to fwildclusterboot

### DIFF
--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -13,3 +13,11 @@
 
   invisible()
 }
+
+.onAttach <- 
+function(libname, pkgname) {
+  packageStartupMessage("\nPlease cite as: \n")
+  packageStartupMessage(" Fischer & Roodman. (2021). fwildclusterboot: Fast Wild Cluster.")
+  packageStartupMessage(" Bootstrap Inference for Linear Regression Models.")
+  packageStartupMessage(" Available from https://cran.r-project.org/package=fwildclusterboot\.")
+}


### PR DESCRIPTION
I noticed that Marek has (rightly) more than 1k citations to stargazer. https://scholar.google.com/citations?user=jRCc4kMAAAAJ&hl=en I think one of the reasons is that the package produces a message onAttach to remind the user to cite the package. I have made a similar change here. I think there is a larger point here about increasing citations to software to improve incentives for software producers and also make sure concerns in software can be backtraced from papers that rely on it.